### PR TITLE
Add ko-US locale test case in webos-js

### DIFF
--- a/webos-js/project.json
+++ b/webos-js/project.json
@@ -21,8 +21,9 @@
     "settings": {
         "xliffsDir": "./xliffs",
         "locales":[
+            "de-DE",
             "ko-KR",
-            "de-DE"
+            "ko-US"
         ]
     }
 }

--- a/webos-js/src/msg.js
+++ b/webos-js/src/msg.js
@@ -10,6 +10,9 @@ export function findMsgByCode (code) {
         case 3:
             msg.reason = $L('Congratulation');
             break;
+        case 4:
+            msg.reason = $L('Antenna NEXTGEN TV');
+            break;
         default:
             msg.reason = $L('Bye');
             break;

--- a/webos-js/xliffs/ko-US.xliff
+++ b/webos-js/xliffs/ko-US.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="ko-US" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-js_f1" original="sample-webos-js">
+    <group id="sample-webos-js_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>Antenna NEXTGEN TV</source>
+          <target>안테나 NEXTGEN TV</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>


### PR DESCRIPTION
Add sample to test ko-US locale case in the webos-js app.
In order to get the correct result, https://github.com/iLib-js/iLib/pull/370 should be applied.