### PR TITLE
Add webos's appinfo.json files localization sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ It is optimized for webOS web applications
 The source files are in `src/*.cpp` and
 the output goes into `resources/[locale]/cppstrings.json`.
 
+- webos-appinfojson - a sample project containing appinfo.json files to translate.
+It is optimized for webOS web applications
+The source files are in `appinfo.json` and
+the output goes into `resources/[locale]/appinfo.json`.
+
 - salesforce - a sample project containing a sales for apex app
 to translate. It contains the main translation-meta.xml as well
 as a number of other meta xml files that contain the source

--- a/webos-appinfojson/appinfo.json
+++ b/webos-appinfojson/appinfo.json
@@ -1,0 +1,18 @@
+{
+	"id": "com.app.livetv",
+	"version": "4.0.1",
+	"type": "web",
+	"main": "index.html",
+	"title": "Live TV",
+	"icon": "icon.png",
+	"uiRevision": 2,
+	"transparent": true,
+	"visible": false,
+	"lockable": false,
+	"trustLevel": "trusted",
+	"accessibility": {
+		"supportsAudioGuidance": true
+	},
+	"voiceControl": "manual",
+	"v8SnapshotFile": "snapshot_blob.bin"
+}

--- a/webos-appinfojson/package.json
+++ b/webos-appinfojson/package.json
@@ -1,0 +1,17 @@
+{
+    "name": "sample-webos-appinfo",
+    "description": "Sample localization project",
+    "repository": "git@github.com:iLib-js/ilib-loctool-samples.git",
+    "license": "Apache-2.0",
+    "version": "1.0.0",
+    "scripts": {
+        "loc": "loctool -2 --xliffStyle custom",
+        "debug": "node --inspect-brk node_modules/loctool/loctool.js -2 --xliffStyle custom",
+        "clean": "rm -rf *.xliff resources",
+        "test": "echo success"
+    },
+    "devDependencies": {
+        "ilib-loctool-webos-appinfo-json": "^1.2.10",
+        "loctool": "^2.16.3"
+    }
+}

--- a/webos-appinfojson/project.json
+++ b/webos-appinfojson/project.json
@@ -1,0 +1,30 @@
+{
+    "name": "sample-webos-appinfo",
+    "id": "sample-webos-appinfo",
+    "projectType": "custom",
+    "sourceLocale": "en-KR",
+    "pseudoLocale": ["zxx-XX", "zxx-Cyrl-XX", "zxx-Hans-XX", "zxx-Hebr-XX"],
+    "resourceDirs": {
+        "json": "resources"
+    },
+    "resourceFileTypes": {
+        "json":"ilib-loctool-webos-appinfo-json"
+    },
+    "plugins": [
+        "ilib-loctool-webos-appinfo-json"
+    ],
+    "excludes": [
+        ".*",
+        "xliffs"
+    ],
+    "settings": {
+        "xliffsDir": "./xliffs",
+        "locales":[
+            "ko-KR",
+            "zh-Hans-CN",
+            "zh-Hant-HK",
+            "zh-Hant-TW"
+        ]
+
+    }
+}

--- a/webos-appinfojson/xliffs/ko-KR.xliff
+++ b/webos-appinfojson/xliffs/ko-KR.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="ko-KR" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-appinfo_f1" original="sample-webos-appinfo">
+    <group id="sample-webos-appinfo_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>Live TV</source>
+          <target>현재 방송</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/webos-appinfojson/xliffs/zh-Hans-CN.xliff
+++ b/webos-appinfojson/xliffs/zh-Hans-CN.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="zh-Hans-CN" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-appinfo_f1" original="sample-webos-appinfo">
+    <group id="sample-webos-appinfo_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>Live TV</source>
+          <target>直播电视</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/webos-appinfojson/xliffs/zh-Hant-HK.xliff
+++ b/webos-appinfojson/xliffs/zh-Hant-HK.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="zh-Hant-HK" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-appinfo_f1" original="sample-webos-appinfo">
+    <group id="sample-webos-appinfo_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>Live TV</source>
+          <target>Live TV</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/webos-appinfojson/xliffs/zh-Hant-TW.xliff
+++ b/webos-appinfojson/xliffs/zh-Hant-TW.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="zh-Hant-TW" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-appinfo_f1" original="sample-webos-appinfo">
+    <group id="sample-webos-appinfo_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>Live TV</source>
+          <target>直播電視</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>


### PR DESCRIPTION
Add webos's appinfo.json files localization sample.
note) In order to get correct reesult, https://github.com/iLib-js/ilib-loctool-webos-appinfo-json/pull/25 should be applied (regarding zh-* localization)
