### PR TITLE
Update webos-js to check override baseLocale feature

### DIFF
--- a/webos-js/package.json
+++ b/webos-js/package.json
@@ -5,8 +5,8 @@
     "license": "Apache-2.0",
     "version": "1.0.0",
     "scripts": {
-        "loc": "loctool -2 --xliffStyle custom",
-        "debug": "node --inspect-brk node_modules/loctool/loctool.js -2 --xliffStyle custom",
+        "loc": "loctool -2 --xliffStyle custom --localeMap es-CO:es,fr-CA:fr",
+        "debug": "node --inspect-brk node_modules/loctool/loctool.js -2 --xliffStyle custom --localeMap es-CO:es",
         "clean": "rm -rf *.xliff resources",
         "test": "echo success"
     },

--- a/webos-js/package.json
+++ b/webos-js/package.json
@@ -11,9 +11,9 @@
         "test": "echo success"
     },
     "devDependencies": {
-        "ilib-loctool-webos-appinfo-json": "^1.2.11",
-        "ilib-loctool-webos-javascript": "^1.4.6",
-        "ilib-loctool-webos-json-resource": "^1.3.10",
+        "ilib-loctool-webos-appinfo-json": "^1.2.12",
+        "ilib-loctool-webos-javascript": "^1.4.7",
+        "ilib-loctool-webos-json-resource": "^1.3.11",
         "loctool": "^2.17.0"
     }
 }

--- a/webos-js/project.json
+++ b/webos-js/project.json
@@ -21,11 +21,15 @@
     "settings": {
         "xliffsDir": "./xliffs",
         "locales":[
+            "de-DE",
             "es-CO",
-            "es-ES"
-        ],
-        "localeMap": {
-            "es-CO": "es"
-        }
+            "es-ES",
+            "en-US",
+            "fr-CA",
+            "fr-FR",
+            "ja-JP",
+            "ko-KR",
+            "ko-US"
+        ]
     }
 }

--- a/webos-js/project.json
+++ b/webos-js/project.json
@@ -30,6 +30,9 @@
             "ja-JP",
             "ko-KR",
             "ko-US"
-        ]
+        ],
+        "localeMap": {
+            "fr-CA": "fr"
+        }
     }
 }

--- a/webos-js/project.json
+++ b/webos-js/project.json
@@ -21,13 +21,11 @@
     "settings": {
         "xliffsDir": "./xliffs",
         "locales":[
-            "de-DE",
-            "en-US",
-            "fr-CA",
-            "fr-FR",
-            "ja-JP",
-            "ko-KR",
-            "ko-US"
-        ]
+            "es-CO",
+            "es-ES"
+        ],
+        "localeMap": {
+            "es-CO": "es"
+        }
     }
 }

--- a/webos-js/src/msg.js
+++ b/webos-js/src/msg.js
@@ -47,6 +47,9 @@ export function findMsgByCode3 (code) {
         case 4:
             msg.reason = $L('TV Name : '); // xliff_target trim
             break;
+        case 5:
+            msg.reason = $L('Sound Out');
+            break;
         default:
             msg.reason = $L('MAC Address'); // xliff_target trim
             break;

--- a/webos-js/xliffs/es-CO.xliff
+++ b/webos-js/xliffs/es-CO.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="es-CO" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-js_f1" original="sample-webos-js">
+    <group id="sample-webos-js_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>Sound Out</source>
+          <target>Salida de Audio</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/webos-js/xliffs/es-ES.xliff
+++ b/webos-js/xliffs/es-ES.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="es-ES" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-js_f1" original="sample-webos-js">
+    <group id="sample-webos-js_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>Sound Out</source>
+          <target>Salida de sonido</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>


### PR DESCRIPTION
* Update webos-js sample to check override baseLocale feature
 * `"loc": "loctool -2 --xliffStyle custom --localeMap es-CO:es,fr-CA:fr"`
 *  related change:
   *  https://github.com/iLib-js/loctool/pull/205, 
   * https://github.com/iLib-js/ilib-loctool-webos-javascript/pull/36
