### PR TITLE
Add localeInherit option sample in webos-js

### DIFF
--- a/webos-js/package.json
+++ b/webos-js/package.json
@@ -13,9 +13,9 @@
         "test": "echo success"
     },
     "dependencies": {
-        "ilib-loctool-webos-appinfo-json": "^1.2.12",
-        "ilib-loctool-webos-javascript": "^1.4.7",
-        "ilib-loctool-webos-json-resource": "^1.3.11",
+        "ilib-loctool-webos-appinfo-json": "^1.3.0",
+        "ilib-loctool-webos-javascript": "^1.5.0",
+        "ilib-loctool-webos-json-resource": "^1.4.0",
         "loctool": "^2.18.0"
     }
 }

--- a/webos-js/package.json
+++ b/webos-js/package.json
@@ -5,8 +5,8 @@
     "license": "Apache-2.0",
     "version": "1.0.0",
     "scripts": {
-        "loc": "loctool -2 --xliffStyle custom --localeMap es-CO:es,fr-CA:fr",
-        "debug": "node --inspect-brk node_modules/loctool/loctool.js -2 --xliffStyle custom --localeMap es-CO:es",
+        "loc": "loctool -2 --xliffStyle custom --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB",
+        "debug": "node --inspect-brk node_modules/loctool/loctool.js -2 --xliffStyle custom --localeMap es-CO:es --localeInherit en-AU:en-GB",
         "loc-generate": "loctool generate -2 -x xliffs --projectType custom --sourceLocale en-KR --resourceFileTypes json=webos-json-resource --plugins webos-javascript,webos-appinfo-json -l ko-US,ko-KR --projectId sample-webos-js",
         "loc-generate-debug": "node --inspect-brk node_modules/loctool/loctool.js generate -2 -x xliffs --projectType custom --sourceLocale en-KR --resourceFileTypes json=webos-json-resource --plugins webos-javascript,webos-appinfo-json -l ko-US,ko-KR --projectId sample-webos-js",
         "clean": "rm -rf *.xliff resources",

--- a/webos-js/package.json
+++ b/webos-js/package.json
@@ -16,6 +16,6 @@
         "ilib-loctool-webos-appinfo-json": "^1.3.0",
         "ilib-loctool-webos-javascript": "^1.5.0",
         "ilib-loctool-webos-json-resource": "^1.4.0",
-        "loctool": "^2.18.0"
+        "loctool": "^2.19.0"
     }
 }

--- a/webos-js/project.json
+++ b/webos-js/project.json
@@ -29,8 +29,6 @@
             "fr-CA": "fr"
         },
         "localeInherit": {
-            "en-AM": "en-GB",
-            "en-AU": "en-GB",
             "en-CN": "en-GB"
         }
     }

--- a/webos-js/project.json
+++ b/webos-js/project.json
@@ -21,7 +21,15 @@
     "settings": {
         "xliffsDir": "./xliffs",
         "locales":[
+            "de-DE",
+            "es-CO",
+            "es-ES",
             "en-US",
+            "fr-CA",
+            "fr-FR",
+            "ja-JP",
+            "ko-KR",
+            "ko-US",
             "en-GB",
             "en-AU"
         ],

--- a/webos-js/project.json
+++ b/webos-js/project.json
@@ -21,18 +21,17 @@
     "settings": {
         "xliffsDir": "./xliffs",
         "locales":[
-            "de-DE",
-            "es-CO",
-            "es-ES",
             "en-US",
-            "fr-CA",
-            "fr-FR",
-            "ja-JP",
-            "ko-KR",
-            "ko-US"
+            "en-GB",
+            "en-AU"
         ],
         "localeMap": {
             "fr-CA": "fr"
+        },
+        "localeInherit": {
+            "en-AM": "en-GB",
+            "en-AU": "en-GB",
+            "en-CN": "en-GB"
         }
     }
 }

--- a/webos-js/src/msg.js
+++ b/webos-js/src/msg.js
@@ -50,6 +50,12 @@ export function findMsgByCode3 (code) {
         case 5:
             msg.reason = $L('Sound Out');
             break;
+        case 6:
+            msg.reason = $L('TV Program Locks');
+            break;
+        case 7:
+            msg.reason = $L('Service Area Zip Code');
+            break;
         default:
             msg.reason = $L('MAC Address'); // xliff_target trim
             break;

--- a/webos-js/xliffs/en-GB.xliff
+++ b/webos-js/xliffs/en-GB.xliff
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="en-GB" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-js_f1" original="sample-webos-js">
+    <group id="sample-webos-js_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>TV Program Locks</source>
+          <target>TV Rating Locks</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>Service Area Zip Code</source>
+          <target>Service Area Postcode</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/webos-js/xliffs/en-US.xliff
+++ b/webos-js/xliffs/en-US.xliff
@@ -20,6 +20,18 @@
           <target>TV Name : </target>
         </segment>
       </unit>
+      <unit id="4">
+        <segment>
+          <source>TV Program Locks</source>
+          <target>TV Program Locks</target>
+        </segment>
+      </unit>
+      <unit id="5">
+        <segment>
+          <source>Service Area Zip Code</source>
+          <target>Service Area Zip Code</target>
+        </segment>
+      </unit>
     </group>
   </file>
 </xliff>


### PR DESCRIPTION
* sample for testing `--localeInherit` option.
   * In order to get the correct result, the loctool version should be `2.19.0`.
   * Both en/AU/strings.json and en/GB/strings.json files are generated.