### PR TITLE
Add localeInherit option sample in webos-c/cpp/qml/appinfojson

### DIFF
--- a/webos-appinfojson/package.json
+++ b/webos-appinfojson/package.json
@@ -5,13 +5,13 @@
     "license": "Apache-2.0",
     "version": "1.0.0",
     "scripts": {
-        "loc": "loctool -2 --xliffStyle custom --localeMap es-CO:es",
-        "debug": "node --inspect-brk node_modules/loctool/loctool.js -2 --xliffStyle custom --localeMap es-CO:es",
+        "loc": "loctool -2 --xliffStyle custom --localeMap es-CO:es --localeInherit en-AU:en-GB",
+        "debug": "node --inspect-brk node_modules/loctool/loctool.js -2 --xliffStyle custom --localeMap es-CO:es --localeInherit en-AU:en-GB",
         "clean": "rm -rf *.xliff resources",
         "test": "echo success"
     },
     "devDependencies": {
-        "ilib-loctool-webos-appinfo-json": "^1.2.12",
-        "loctool": "^2.18.0"
+        "ilib-loctool-webos-appinfo-json": "^1.3.0",
+        "loctool": "^2.19.0"
     }
 }

--- a/webos-appinfojson/project.json
+++ b/webos-appinfojson/project.json
@@ -20,6 +20,9 @@
     "settings": {
         "xliffsDir": "./xliffs",
         "locales":[
+            "en-AU",
+            "en-GB",
+            "en-US",
             "es-CO",
             "es-ES",
             "fr-CA",

--- a/webos-appinfojson/xliffs/en-GB.xliff
+++ b/webos-appinfojson/xliffs/en-GB.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="en-GB" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-appinfo_f1" original="sample-webos-appinfo">
+    <group id="sample-webos-appinfo_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>Live TV</source>
+          <target>(en-GB) Live TV</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/webos-appinfojson/xliffs/en-US.xliff
+++ b/webos-appinfojson/xliffs/en-US.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-appinfo_f1" original="sample-webos-appinfo">
+    <group id="sample-webos-appinfo_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>Live TV</source>
+          <target>(en-US) Live TV</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/webos-c/package.json
+++ b/webos-c/package.json
@@ -5,16 +5,16 @@
     "license": "Apache-2.0",
     "version": "1.0.0",
     "scripts": {
-        "loc": "loctool -2 --xliffStyle custom --localeMap es-CO:es",
-        "debug": "node --inspect-brk node_modules/loctool/loctool.js -2 --xliffStyle custom --localeMap es-CO:es",
+        "loc": "loctool -2 --xliffStyle custom --localeMap es-CO:es --localeInherit en-AU:en-GB",
+        "debug": "node --inspect-brk node_modules/loctool/loctool.js -2 --xliffStyle custom --localeMap es-CO:es --localeInherit en-AU:en-GB",
         "loc-generate": "loctool generate -2 -x xliffs --projectType custom --sourceLocale en-KR --resourceFileTypes json=webos-json-resource --resourceFileNames json=cstrings.json --plugins webos-c -l ko-KR --projectId sample-webos-c",
         "loc-generate-debug": "node --inspect-brk node_modules/loctool/loctool.js generate -2 -x xliffs --projectType custom --sourceLocale en-KR --resourceFileTypes json=webos-json-resource --plugins webos-c -l ko-KR --projectId sample-webos-c",
         "clean": "rm -rf *.xliff resources",
         "test": "echo success"
     },
     "dependencies": {
-        "ilib-loctool-webos-c": "^1.1.7",
-        "ilib-loctool-webos-json-resource": "^1.3.11",
-        "loctool": "^2.18.0"
+        "ilib-loctool-webos-c": "^1.2.0",
+        "ilib-loctool-webos-json-resource": "^1.4.0",
+        "loctool": "^2.19.0"
     }
 }

--- a/webos-c/project.json
+++ b/webos-c/project.json
@@ -22,6 +22,8 @@
         "xliffsDir": "./xliffs",
         "locales":[
             "en-US",
+            "en-GB",
+            "en-AU",
             "es-CO",
             "es-ES",
             "fr-CA",

--- a/webos-c/src/list.c
+++ b/webos-c/src/list.c
@@ -1,3 +1,5 @@
 char *localized_string = (gchar*)resBundle_getLocString(_g_res_bundle_object, "Ivory Coast");
 char *localized_string2 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "Programme");
 char *localized_string3 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "Sound Out");
+char *localized_string4 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "TV Program Locks");
+char *localized_string5 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "Service Area Zip Code");

--- a/webos-c/xliffs/en-GB.xliff
+++ b/webos-c/xliffs/en-GB.xliff
@@ -1,26 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">
+<xliff version="2.0" srcLang="en-KR" trgLang="en-GB" xmlns:l="http://ilib-js.com/loctool">
   <file id="sample-webos-c_f1" original="sample-webos-c">
     <group id="sample-webos-c_g1" name="c">
       <unit id="1">
-        <segment>
-          <source>Ivory Coast</source>
-          <target>Côte d’Ivoire</target>
-        </segment>
-      </unit>
-      <unit id="2">
-        <segment>
-          <source>Programme</source>
-          <target>Channel</target>
-        </segment>
-      </unit>
-      <unit id="3">
         <segment>
           <source>TV Program Locks</source>
           <target>TV Rating Locks</target>
         </segment>
       </unit>
-      <unit id="4">
+      <unit id="2">
         <segment>
           <source>Service Area Zip Code</source>
           <target>Service Area Postcode</target>

--- a/webos-c/xliffs/en-US.xliff
+++ b/webos-c/xliffs/en-US.xliff
@@ -17,13 +17,13 @@
       <unit id="3">
         <segment>
           <source>TV Program Locks</source>
-          <target>TV Rating Locks</target>
+          <target>TV Program Locks</target>
         </segment>
       </unit>
       <unit id="4">
         <segment>
           <source>Service Area Zip Code</source>
-          <target>Service Area Postcode</target>
+          <target>Service Area Zip Code</target>
         </segment>
       </unit>
     </group>

--- a/webos-cpp/package.json
+++ b/webos-cpp/package.json
@@ -5,16 +5,16 @@
     "license": "Apache-2.0",
     "version": "1.0.0",
     "scripts": {
-        "loc": "loctool -2 --xliffStyle custom --localeMap es-CO:es",
-        "debug": "node --inspect-brk node_modules/loctool/loctool.js -2 --xliffStyle custom --localeMap es-CO:es",
+        "loc": "loctool -2 --xliffStyle custom --localeMap es-CO:es --localeInherit en-AU:en-GB",
+        "debug": "node --inspect-brk node_modules/loctool/loctool.js -2 --xliffStyle custom --localeMap es-CO:es --localeInherit en-AU:en-GB",
         "loc-generate": "loctool generate -2 -x xliffs --projectType custom --sourceLocale en-KR --resourceFileTypes json=webos-json-resource --resourceFileNames json=cppstrings.json --plugins webos-cpp -l ko-KR --projectId sample-webos-cpp",
         "loc-generate-debug": "node --inspect-brk node_modules/loctool/loctool.js generate -2 -x xliffs --projectType custom --sourceLocale en-KR --resourceFileTypes json=webos-json-resource --plugins webos-cpp -l ko-KR --projectId sample-webos-cpp",
         "clean": "rm -rf *.xliff resources",
         "test": "echo success"
     },
     "dependencies": {
-        "ilib-loctool-webos-cpp": "^1.1.7",
-        "ilib-loctool-webos-json-resource": "^1.3.11",
-        "loctool": "^2.18.0"
+        "ilib-loctool-webos-cpp": "^1.2.0",
+        "ilib-loctool-webos-json-resource": "^1.4.0",
+        "loctool": "^2.19.0"
     }
 }

--- a/webos-cpp/project.json
+++ b/webos-cpp/project.json
@@ -21,6 +21,8 @@
     "settings": {
         "xliffsDir": "./xliffs",
         "locales":[
+            "en-AU",
+            "en-GB",
             "en-US",
             "es-CO",
             "es-ES",

--- a/webos-cpp/src/test.cpp
+++ b/webos-cpp/src/test.cpp
@@ -23,6 +23,8 @@ bool get_checking_update(AppLaunchingItem prelaunching_item,)
         std::string agree_label        = ResBundleAdaptor::instance().getLocString("Agree");
         std::string program_label      = ResBundleAdaptor::instance().getLocString("Programme");
         std::string ivory_label        = ResBundleAdaptor::instance().getLocString("Ivory Coast");
+        std::string test1_label        = ResBundleAdaptor::instance().getLocString("TV Program Locks");
+        std::string test2_label        = ResBundleAdaptor::instance().getLocString("Service Area Zip Code");
         // Layout: [yes] [no]
         buttons.append(yes_btn);
         buttons.append(no_btn);

--- a/webos-cpp/xliffs/en-GB.xliff
+++ b/webos-cpp/xliffs/en-GB.xliff
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="en-GB" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-cpp_f1" original="sample-webos-cpp">
+    <group id="sample-webos-cpp_g1" name="cpp">
+      <unit id="1">
+        <segment>
+          <source>TV Program Locks</source>
+          <target>TV Rating Locks</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>Service Area Zip Code</source>
+          <target>Service Area Postcode</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/webos-cpp/xliffs/en-US.xliff
+++ b/webos-cpp/xliffs/en-US.xliff
@@ -23,7 +23,7 @@
       <unit id="4">
         <segment>
           <source>Service Area Zip Code</source>
-          <target>Service Area Postcode</target>
+          <target>Service Area Zip Code</target>
         </segment>
       </unit>
     </group>

--- a/webos-cpp/xliffs/en-US.xliff
+++ b/webos-cpp/xliffs/en-US.xliff
@@ -14,6 +14,18 @@
           <target>Channel</target>
         </segment>
       </unit>
+      <unit id="3">
+        <segment>
+          <source>TV Program Locks</source>
+          <target>TV Program Locks</target>
+        </segment>
+      </unit>
+      <unit id="4">
+        <segment>
+          <source>Service Area Zip Code</source>
+          <target>Service Area Postcode</target>
+        </segment>
+      </unit>
     </group>
   </file>
 </xliff>

--- a/webos-qml/package.json
+++ b/webos-qml/package.json
@@ -5,8 +5,8 @@
     "license": "Apache-2.0",
     "version": "1.0.0",
     "scripts": {
-        "loc": "loctool -2 --xliffStyle custom --pseudo --localeMap es-CO:es -localeInherit en-AU:en-GB",
-        "debug": "node --inspect-brk node_modules/loctool/loctool.js -2 --xliffStyle custom --pseudo --localeMap es-CO:es -localeInherit en-AU:en-GB",
+        "loc": "loctool -2 --xliffStyle custom --pseudo --localeMap es-CO:es --localeInherit en-AU:en-GB",
+        "debug": "node --inspect-brk node_modules/loctool/loctool.js -2 --xliffStyle custom --pseudo --localeMap es-CO:es --localeInherit en-AU:en-GB",
         "clean": "rm -rf *.xliff resources",
         "test": "echo success"
     },

--- a/webos-qml/package.json
+++ b/webos-qml/package.json
@@ -5,14 +5,14 @@
     "license": "Apache-2.0",
     "version": "1.0.0",
     "scripts": {
-        "loc": "loctool -2 --xliffStyle custom --pseudo --localeMap es-CO:es",
-        "debug": "node --inspect-brk node_modules/loctool/loctool.js -2 --xliffStyle custom --pseudo --localeMap es-CO:es",
+        "loc": "loctool -2 --xliffStyle custom --pseudo --localeMap es-CO:es -localeInherit en-AU:en-GB",
+        "debug": "node --inspect-brk node_modules/loctool/loctool.js -2 --xliffStyle custom --pseudo --localeMap es-CO:es -localeInherit en-AU:en-GB",
         "clean": "rm -rf *.xliff resources",
         "test": "echo success"
     },
     "devDependencies": {
-        "ilib-loctool-webos-qml": "^1.3.6",
-        "ilib-loctool-webos-ts-resource": "^1.2.10",
-        "loctool": "^2.18.0"
+        "ilib-loctool-webos-qml": "^1.3.7",
+        "ilib-loctool-webos-ts-resource": "^1.3.0",
+        "loctool": "^2.19.0"
     }
 }

--- a/webos-qml/project.json
+++ b/webos-qml/project.json
@@ -21,6 +21,8 @@
     "settings": {
         "xliffsDir": "./xliffs",
         "locales":[
+            "en-AU",
+            "en-GB",
             "es-CO",
             "es-ES",
             "ko-KR",

--- a/webos-qml/project.json
+++ b/webos-qml/project.json
@@ -22,6 +22,7 @@
         "xliffsDir": "./xliffs",
         "locales":[
             "en-AU",
+            "en-US",
             "en-GB",
             "es-CO",
             "es-ES",

--- a/webos-qml/src/StringSheet.qml
+++ b/webos-qml/src/StringSheet.qml
@@ -24,6 +24,8 @@ AppStringSheet {
             qsTr("Artists") + es,
             qsTr("Songs") + es,
             qsTr("Genres") + es
+            qsTr("TV Program Locks") + es
+            qsTr("Service Area Zip Code") + es
         ]
     }
 }

--- a/webos-qml/xliffs/en-GB.xliff
+++ b/webos-qml/xliffs/en-GB.xliff
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="en-GB" xmlns:l="http://ilib-js.com/loctool">
+  <file id="music_f1" original="music">
+    <group id="music_g1" name="x-qml">
+      <unit id="1">
+        <segment>
+          <source>TV Program Locks</source>
+          <target>TV Rating Locks</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>Service Area Zip Code</source>
+          <target>Service Area Postcode</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/webos-qml/xliffs/en-US.xliff
+++ b/webos-qml/xliffs/en-US.xliff
@@ -23,7 +23,7 @@
       <unit id="4">
         <segment>
           <source>Service Area Zip Code</source>
-          <target>Service Area Postcode</target>
+          <target>Service Area Zip Code</target>
         </segment>
       </unit>
     </group>

--- a/webos-qml/xliffs/en-US.xliff
+++ b/webos-qml/xliffs/en-US.xliff
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">
-  <file id="sample-webos-c_f1" original="sample-webos-c">
-    <group id="sample-webos-c_g1" name="c">
+  <file id="music_f1" original="music">
+    <group id="music_g1" name="x-qml">
       <unit id="1">
         <segment>
           <source>Ivory Coast</source>
@@ -17,7 +17,7 @@
       <unit id="3">
         <segment>
           <source>TV Program Locks</source>
-          <target>TV Rating Locks</target>
+          <target>TV Program Locks</target>
         </segment>
       </unit>
       <unit id="4">

--- a/webos-qml/xliffs/en-US.xliff
+++ b/webos-qml/xliffs/en-US.xliff
@@ -4,23 +4,11 @@
     <group id="music_g1" name="x-qml">
       <unit id="1">
         <segment>
-          <source>Ivory Coast</source>
-          <target>Côte d’Ivoire</target>
-        </segment>
-      </unit>
-      <unit id="2">
-        <segment>
-          <source>Programme</source>
-          <target>Channel</target>
-        </segment>
-      </unit>
-      <unit id="3">
-        <segment>
           <source>TV Program Locks</source>
           <target>TV Program Locks</target>
         </segment>
       </unit>
-      <unit id="4">
+      <unit id="2">
         <segment>
           <source>Service Area Zip Code</source>
           <target>Service Area Zip Code</target>


### PR DESCRIPTION
* sample for testing --localeInherit option
  * The minimum version of loctool should be `2.19.0`
  * Both en/AU/strings.json and en/GB/strings.json files are generated even en-AU xliff file does not exist