### PR TITLE
Update webos samples to check issues

### DIFF
--- a/webos-appinfojson/appinfo.json
+++ b/webos-appinfojson/appinfo.json
@@ -14,5 +14,6 @@
 		"supportsAudioGuidance": true
 	},
 	"voiceControl": "manual",
-	"v8SnapshotFile": "snapshot_blob.bin"
+	"v8SnapshotFile": "snapshot_blob.bin",
+	"vendor": "test"
 }

--- a/webos-appinfojson/package.json
+++ b/webos-appinfojson/package.json
@@ -12,6 +12,6 @@
     },
     "devDependencies": {
         "ilib-loctool-webos-appinfo-json": "^1.4.1",
-        "loctool": "^2.20.0"
+        "loctool": "^2.20.2"
     }
 }

--- a/webos-appinfojson/project.json
+++ b/webos-appinfojson/project.json
@@ -16,7 +16,8 @@
     "excludes": [
         ".*",
         "xliffs",
-        "resources"
+        "resources",
+        "common"
     ],
     "settings": {
         "xliffsDir": "./xliffs",

--- a/webos-appinfojson/xliffs/en-GB.xliff
+++ b/webos-appinfojson/xliffs/en-GB.xliff
@@ -8,6 +8,12 @@
           <target>(en-GB) Live TV</target>
         </segment>
       </unit>
+      <unit id="2">
+        <segment>
+          <source>test</source>
+          <target>(dup) test</target>
+        </segment>
+      </unit>
     </group>
   </file>
 </xliff>

--- a/webos-appinfojson/xliffs/en-US.xliff
+++ b/webos-appinfojson/xliffs/en-US.xliff
@@ -8,6 +8,12 @@
           <target>(en-US) Live TV</target>
         </segment>
       </unit>
+      <unit id="2">
+        <segment>
+          <source>test</source>
+          <target>(dup) test</target>
+        </segment>
+      </unit>
     </group>
   </file>
 </xliff>

--- a/webos-js/common/en-GB.xliff
+++ b/webos-js/common/en-GB.xliff
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="en-GB" xmlns:l="http://ilib-js.com/loctool">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="common_1">
+        <segment>
+          <source>Game Optimizer</source>
+          <target>Game Optimiser</target>
+        </segment>
+      </unit>
+      <unit id="common_2">
+        <segment>
+          <source>HDMI Deep Color</source>
+          <target>HDMI Deep Colour</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/webos-js/package.json
+++ b/webos-js/package.json
@@ -16,11 +16,11 @@
         "test-generate:all": "npm-run-all clean loc-generate test-generate"
     },
     "dependencies": {
-        "ilib": "^14.15.1",
+        "ilib": "^14.16.0",
         "ilib-loctool-webos-appinfo-json": "^1.4.1",
         "ilib-loctool-webos-javascript": "^1.7.0",
         "ilib-loctool-webos-json-resource": "^1.4.1",
-        "loctool": "^2.20.0"
+        "loctool": "^2.20.2"
     },
     "devDependencies": {
         "npm-run-all": "^4.1.5"

--- a/webos-js/project.json
+++ b/webos-js/project.json
@@ -17,7 +17,8 @@
     "excludes": [
         ".*",
         "test",
-        "xliffs"
+        "xliffs",
+        "common"
     ],
     "settings": {
         "xliffsDir": "./xliffs",
@@ -32,13 +33,15 @@
             "ko-KR",
             "ko-US",
             "en-AU",
-            "en-GB"
+            "en-GB",
+            "en-AU"
         ],
         "localeMap": {
             "fr-CA": "fr"
         },
         "localeInherit": {
-            "en-CN": "en-GB"
+            "en-CN": "en-GB",
+            "en-AU": "en-GB"
         },
         "webos": {
             "commonXliff": "./common"

--- a/webos-js/project.json
+++ b/webos-js/project.json
@@ -16,6 +16,7 @@
     ],
     "excludes": [
         ".*",
+        "test",
         "xliffs"
     ],
     "settings": {

--- a/webos-js/src/msg.js
+++ b/webos-js/src/msg.js
@@ -13,6 +13,12 @@ export function findMsgByCode (code) {
         case 4:
             msg.reason = $L('Antenna NEXTGEN TV');
             break;
+        case 5:
+            msg.reason = $L('Game Optimizer');
+            break;
+        case 6:
+            msg.reason = $L('HDMI Deep Color');
+            break;
         default:
             msg.reason = $L('Bye');
             break;

--- a/webos-js/src/msg.js
+++ b/webos-js/src/msg.js
@@ -70,6 +70,8 @@ export function findMsgByCode3 (code) {
             break;
         case 10:
             msg.reason = $L('Others');
+        case 11:
+            $L("Go to  'Settings > General > Channels > Channel Tuning & Settings > Transponder Edit' and add one.")
             break;
         default:
             msg.reason = $L('MAC Address'); // xliff_target trim

--- a/webos-js/test/testResourceLocalize.js
+++ b/webos-js/test/testResourceLocalize.js
@@ -59,9 +59,12 @@ function testenGB(){
     // common data's locale Inheritence
     var result1 = rb.getString("Game Optimizer").toString();
     var result2 = rb.getString("HDMI Deep Color").toString();
+    //multi-space
+    var result3 = rb.getString("Go to  'Settings > General > Channels > Channel Tuning & Settings > Transponder Edit' and add one.").toString();
 
     logResults(arguments.callee.name, "Game Optimiser", result1);
     logResults(arguments.callee.name, "HDMI Deep Colour", result2);
+    logResults(arguments.callee.name, "Go to 'Settings > General > Programmes > Programme Tuning & Settings > Transponder Edit' and add one.", result3);
 }
 
 function testenAU(){
@@ -72,9 +75,12 @@ function testenAU(){
     // common data's locale Inheritence
     var result1 = rb.getString("Game Optimizer").toString();
     var result2 = rb.getString("HDMI Deep Color").toString();
+    //multi-space
+    var result3 = rb.getString("Go to  'Settings > General > Channels > Channel Tuning & Settings > Transponder Edit' and add one.").toString();
 
     logResults(arguments.callee.name, "Game Optimiser", result1);
     logResults(arguments.callee.name, "HDMI Deep Colour", result2);
+    logResults(arguments.callee.name, "Go to 'Settings > General > Programmes > Programme Tuning & Settings > Transponder Edit' and add one.", result3);
 }
 
 testkoKR();

--- a/webos-js/test/testResourceLocalize.js
+++ b/webos-js/test/testResourceLocalize.js
@@ -1,7 +1,7 @@
 /*
  * testResourcesLocalize.js - test file for normal `localize` mode output
  *
- * Copyright © 2022 JEDLSoft
+ * Copyright © 2022-2023 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ function logResults(testname, expected, actual) {
         console.log(testname + " is failed." +  "\n\texpected:\t"+expected+"\tactual:\t\t"+actual);
     }
 }
-   
+
 console.log("\n***** Run `testResourceLocalize.js` file  *****");
 function testkoKR(){
     var rb = new ResBundle({
@@ -51,5 +51,33 @@ function testjaJP(){
     logResults(arguments.callee.name, "利用規約を読むには、設定 > サポート > 利用規約 & 法的情報に移動します。", result1);
 }
 
+function testenGB(){
+    var rb = new ResBundle({
+        locale:"en-GB",
+        basePath : defaultRSPath
+    });
+    // common data's locale Inheritence
+    var result1 = rb.getString("Game Optimizer").toString();
+    var result2 = rb.getString("HDMI Deep Color").toString();
+
+    logResults(arguments.callee.name, "Game Optimiser", result1);
+    logResults(arguments.callee.name, "HDMI Deep Colour", result2);
+}
+
+function testenAU(){
+    var rb = new ResBundle({
+        locale:"en-AU",
+        basePath : defaultRSPath
+    });
+    // common data's locale Inheritence
+    var result1 = rb.getString("Game Optimizer").toString();
+    var result2 = rb.getString("HDMI Deep Color").toString();
+
+    logResults(arguments.callee.name, "Game Optimiser", result1);
+    logResults(arguments.callee.name, "HDMI Deep Colour", result2);
+}
+
 testkoKR();
 testjaJP();
+testenGB();
+testenAU();

--- a/webos-js/xliffs/en-GB.xliff
+++ b/webos-js/xliffs/en-GB.xliff
@@ -26,6 +26,12 @@
           <target>Programme</target>
         </segment>
       </unit>
+      <unit id="5">
+         <segment>
+            <source>Go to  'Settings > General > Channels > Channel Tuning &amp; Settings > Transponder Edit' and add one.</source>
+            <target>Go to 'Settings > General > Programmes > Programme Tuning &amp; Settings > Transponder Edit' and add one.</target>
+          </segment>
+      </unit>
     </group>
   </file>
 </xliff>


### PR DESCRIPTION
webos-js:
 * Fixed an issue where common's locale inheritance data values were not checked.
 * Updated to match translation's reskey and resource's reskey when they are different.

webos-appinfo:
* Fixed not generating duplicated resources by comparing language default locale translation even if the locale follows the locale inheritance rule.
