### PR TITLE
Update single quote usage case in webos-c/cpp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-*/node_modules/
-*/package-lock.json
+**/node_modules/
+**/package-lock.json

--- a/webos-c/src/list.c
+++ b/webos-c/src/list.c
@@ -10,3 +10,4 @@ char *localized_string9 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "
 char *localized_string10 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "Game Optimizer");
 char *localized_string11= (gchar*)resBundle_getLocString(_g_res_bundle_object, "HDMI Deep Color");
 char *localized_string12 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "Exit");
+char *localized_string13 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "Do you want to change the settings from \'Digital Sound Output\' to \'Pass Through\' to minimize audio delay while playing game?");

--- a/webos-c/test/testResources.js
+++ b/webos-c/test/testResources.js
@@ -56,9 +56,11 @@ function testkoKR(){
     var loadData = loadJSON("ko/cstrings.json");
     var result1 = loadData["No"];
     var result2 = loadData["OK"];
+    var result3 = loadData["Do you want to change the settings from 'Digital Sound Output' to 'Pass Through' to minimize audio delay while playing game?"];
                   
     logResults(arguments.callee.name, "아니오", result1);
     logResults(arguments.callee.name, "확인", result2);
+    logResults(arguments.callee.name, "'디지털 음향 내보내기' 를 오디오 지연을 최소화하여 게임을 즐길 수 있는 'Pass Through'로 변경할까요?", result3);
 }
 
 function testenUS(){
@@ -118,20 +120,24 @@ function testfrCA(){
     var result2 = loadData["Programme"];
     var result3 = loadData["Others"];
     var result4 = loadData["Exit"];
+    var result5 = loadData["Do you want to change the settings from 'Digital Sound Output' to 'Pass Through' to minimize audio delay while playing game?"];
 
     logResults(arguments.callee.name, "D’accord", result1);
     logResults(arguments.callee.name, "Programme", result2);
     logResults(arguments.callee.name, "Autres", result3);
     logResults(arguments.callee.name, "Quitter", result4);
+    logResults(arguments.callee.name, "Voulez-vous changer les paramètres de « Sortie audio numérique » à « Passage » pour minimiser le délai audio pendant les jeux?", result5);
 }
 
 function testfrFR(){
     var loadData = loadJSON("fr/FR/cstrings.json");
     var result1 = loadData["Agree"];
+    var result2 = loadData["Do you want to change the settings from 'Digital Sound Output' to 'Pass Through' to minimize audio delay while playing game?"];
     var existKey = isExistKey("fr/FR/cstrings.json", "Others");
     var existKey2 = isExistKey("fr/FR/cstrings.json", "Exit");
     
     logResults(arguments.callee.name, "J'accepte", result1);
+    logResults(arguments.callee.name, "Souhaitez-vous modifier les paramètres de « Sortie audio numérique » en « Interconnexion » pour limiter le décalage audio pendant le jeu ?", result2);
     logResults(arguments.callee.name, false, existKey);
     logResults(arguments.callee.name, false, existKey2);
 }

--- a/webos-c/xliffs/fr-CA.xliff
+++ b/webos-c/xliffs/fr-CA.xliff
@@ -26,6 +26,12 @@
           <target>Autres</target>
         </segment>
       </unit>
+      <unit id="5">
+        <segment>
+          <source>Do you want to change the settings from 'Digital Sound Output' to 'Pass Through' to minimize audio delay while playing game?</source>
+          <target>Voulez-vous changer les paramètres de « Sortie audio numérique » à « Passage » pour minimiser le délai audio pendant les jeux?</target>
+        </segment>
+      </unit>
     </group>
   </file>
 </xliff>

--- a/webos-c/xliffs/fr-FR.xliff
+++ b/webos-c/xliffs/fr-FR.xliff
@@ -20,6 +20,12 @@
           <target>J'accepte</target>
         </segment>
       </unit>
+      <unit id="4">
+        <segment>
+          <source>Do you want to change the settings from 'Digital Sound Output' to 'Pass Through' to minimize audio delay while playing game?</source>
+          <target>Souhaitez-vous modifier les paramètres de « Sortie audio numérique » en « Interconnexion » pour limiter le décalage audio pendant le jeu ?</target>
+        </segment>
+      </unit>
     </group>
   </file>
 </xliff>

--- a/webos-c/xliffs/ko-KR.xliff
+++ b/webos-c/xliffs/ko-KR.xliff
@@ -26,6 +26,12 @@
           <target>[App] 시간 설정</target>
         </segment>
       </unit>
+      <unit id="5">
+        <segment>
+          <source>Do you want to change the settings from 'Digital Sound Output' to 'Pass Through' to minimize audio delay while playing game?</source>
+          <target>'디지털 음향 내보내기' 를 오디오 지연을 최소화하여 게임을 즐길 수 있는 'Pass Through'로 변경할까요?</target>
+        </segment>
+      </unit>
     </group>
   </file>
 </xliff>

--- a/webos-cpp/src/test.cpp
+++ b/webos-cpp/src/test.cpp
@@ -38,4 +38,7 @@ bool get_checking_update(AppLaunchingItem prelaunching_item,)
         buttons.append(yes_btn);
         buttons.append(no_btn);
     }
+    if (pResBundle) {
+        trans1 = pResBundle->getLocString("Do you want to change the settings from \'Digital Sound Output\' to \'Pass Through\' to minimize audio delay while playing game?");
+    }
 }

--- a/webos-cpp/test/testResources.js
+++ b/webos-cpp/test/testResources.js
@@ -119,6 +119,7 @@ function testfrCA(){
     var result1 = loadData["Agree"];
     var result2 = loadData["Programme"];
     var result3 = loadData["Others"];
+    var result5 = loadData["Do you want to change the settings from 'Digital Sound Output' to 'Pass Through' to minimize audio delay while playing game?"];
     //common data
     var result4 = loadData["Exit"];
 
@@ -126,15 +127,18 @@ function testfrCA(){
     logResults(arguments.callee.name, "Programme", result2);
     logResults(arguments.callee.name, "Autres", result3);
     logResults(arguments.callee.name, "Quitter", result4);
+    logResults(arguments.callee.name, "Voulez-vous changer les paramètres de « Sortie audio numérique » à « Passage » pour minimiser le délai audio pendant les jeux?", result5);
 }
 
 function testfrFR(){
     var loadData = loadJSON("fr/FR/cppstrings.json");
     var result1 = loadData["Agree"];
+    var result2 = loadData["Do you want to change the settings from 'Digital Sound Output' to 'Pass Through' to minimize audio delay while playing game?"];
     var existKey = isExistKey("fr/FR/cppstrings.json", "Others");
     var existKey2 = isExistKey("fr/FR/cppstrings.json", "Exit");
     
     logResults(arguments.callee.name, "J'accepte", result1);
+    logResults(arguments.callee.name, "Souhaitez-vous modifier les paramètres de « Sortie audio numérique » en « Interconnexion » pour limiter le décalage audio pendant le jeu ?", result2);
     logResults(arguments.callee.name, false, existKey);
     logResults(arguments.callee.name, false, existKey2);
 }

--- a/webos-cpp/test/testResources.js
+++ b/webos-cpp/test/testResources.js
@@ -56,9 +56,11 @@ function testkoKR(){
     var loadData = loadJSON("ko/cppstrings.json");
     var result1 = loadData["No"];
     var result2 = loadData["Update"];
+    var result3 = loadData["Do you want to change the settings from 'Digital Sound Output' to 'Pass Through' to minimize audio delay while playing game?"];
                   
     logResults(arguments.callee.name, "아니오", result1);
     logResults(arguments.callee.name, "업데이트", result2);
+    logResults(arguments.callee.name, "'디지털 음향 내보내기' 를 오디오 지연을 최소화하여 게임을 즐길 수 있는 'Pass Through'로 변경할까요?", result3);
 }
 
 function testenUS(){

--- a/webos-cpp/xliffs/fr-CA.xliff
+++ b/webos-cpp/xliffs/fr-CA.xliff
@@ -26,6 +26,12 @@
           <target>Autres</target>
         </segment>
       </unit>
+      <unit id="5">
+        <segment>
+          <source>Do you want to change the settings from 'Digital Sound Output' to 'Pass Through' to minimize audio delay while playing game?</source>
+          <target>Voulez-vous changer les paramètres de « Sortie audio numérique » à « Passage » pour minimiser le délai audio pendant les jeux?</target>
+        </segment>
+      </unit>
     </group>
   </file>
 </xliff>

--- a/webos-cpp/xliffs/fr-FR.xliff
+++ b/webos-cpp/xliffs/fr-FR.xliff
@@ -44,6 +44,12 @@
           <target>J'accepte</target>
         </segment>
       </unit>
+      <unit id="8">
+        <segment>
+          <source>Do you want to change the settings from 'Digital Sound Output' to 'Pass Through' to minimize audio delay while playing game?</source>
+          <target>Souhaitez-vous modifier les paramètres de « Sortie audio numérique » en « Interconnexion » pour limiter le décalage audio pendant le jeu ?</target>
+        </segment>
+      </unit>
     </group>
   </file>
 </xliff>

--- a/webos-cpp/xliffs/ko-KR.xliff
+++ b/webos-cpp/xliffs/ko-KR.xliff
@@ -32,6 +32,12 @@
           <target>[App] 시간 설정</target>
         </segment>
       </unit>
+      <unit id="6">
+        <segment>
+          <source>Do you want to change the settings from 'Digital Sound Output' to 'Pass Through' to minimize audio delay while playing game?</source>
+          <target>'디지털 음향 내보내기' 를 오디오 지연을 최소화하여 게임을 즐길 수 있는 'Pass Through'로 변경할까요?</target>
+        </segment>
+      </unit>
     </group>
   </file>
 </xliff>


### PR DESCRIPTION
Add single quote usage case to web-c/webos-cpp example
* cpp: https://github.com/iLib-js/ilib-loctool-webos-cpp/pull/38
* c: https://github.com/iLib-js/ilib-loctool-webos-c/pull/38 