### PR TITLE
Update webos-js/qml sample to check custom pseudo locale

### DIFF
--- a/webos-js/package.json
+++ b/webos-js/package.json
@@ -16,11 +16,11 @@
         "test-generate:all": "npm-run-all clean loc-generate test-generate"
     },
     "dependencies": {
-        "ilib": "^14.17.0",
+        "ilib": "^14.18.0",
         "ilib-loctool-webos-appinfo-json": "^1.6.1",
         "ilib-loctool-webos-javascript": "^1.8.2",
         "ilib-loctool-webos-json-resource": "^1.5.1",
-        "loctool": "^2.20.3"
+        "loctool": "^2.22.0"
     },
     "devDependencies": {
         "npm-run-all": "^4.1.5"

--- a/webos-js/package.json
+++ b/webos-js/package.json
@@ -5,10 +5,10 @@
     "license": "Apache-2.0",
     "version": "1.0.0",
     "scripts": {
-        "loc": "loctool -2 --xliffStyle custom --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB",
-        "debug": "node --inspect-brk node_modules/loctool/loctool.js -2 --xliffStyle custom --localeMap es-CO:es --localeInherit en-AU:en-GB",
+        "loc": "loctool -2 --xliffStyle custom --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB --pseudo",
+        "debug": "node --inspect-brk node_modules/loctool/loctool.js -2 --xliffStyle custom --localeMap es-CO:es --localeInherit en-AU:en-GB --pseudo",
         "clean": "rm -rf *.xliff resources",
-        "loc-generate": "loctool generate -2 -x xliffs --projectType custom --sourceLocale en-KR --resourceFileTypes json=webos-json-resource --plugins webos-javascript,webos-appinfo-json  --projectId sample-webos-js -l de-DE,en-AU,en-US,en-GB,en-JP,es-ES,es-CO,fr-CA,fr-FR,ja-JP,ko-KR,ko-US --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB,en-JP:en-GB",
+        "loc-generate": "loctool generate -2 -x xliffs --projectType custom --sourceLocale en-KR --resourceFileTypes json=webos-json-resource --plugins webos-javascript,webos-appinfo-json  --projectId sample-webos-js -l as-IN,de-DE,en-AU,en-US,en-GB,en-JP,es-ES,es-CO,fr-CA,fr-FR,ja-JP,ko-KR,ko-US --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB,en-JP:en-GB",
         "loc-generate-debug": "node --inspect-brk node_modules/loctool/loctool.js generate -2 -x xliffs --projectType custom --sourceLocale en-KR --resourceFileTypes json=webos-json-resource --plugins webos-javascript,webos-appinfo-json --projectId sample-webos-js -l de-DE,en-AU,en-US,en-GB,en-JP,es-ES,es-CO,fr-CA,fr-FR,ja-JP,ko-KR,ko-US --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB,en-JP,en-GB",
         "test": "node test/testResources.js; node test/testResourceLocalize.js",
         "test-generate": "node test/testResources.js; node test/testResourceGenerate.js",

--- a/webos-js/project.json
+++ b/webos-js/project.json
@@ -3,7 +3,13 @@
     "id": "sample-webos-js",
     "projectType": "custom",
     "sourceLocale": "en-KR",
-    "pseudoLocale": ["zxx-XX", "zxx-Cyrl-XX", "zxx-Hans-XX", "zxx-Hebr-XX"],
+    "pseudoLocale":  {
+        "zxx-XX": "debug",
+        "zxx-Hebr-XX": "debug-rtl",
+        "zxx-Cyrl-XX": "debug-cyrillic",
+        "zxx-Hant-XX":"debug-asian",
+        "as-XX" : "debug-font"
+    },
     "resourceDirs": {
         "json":"resources"
     },
@@ -23,6 +29,7 @@
     "settings": {
         "xliffsDir": "./xliffs",
         "locales":[
+            "as-IN",
             "de-DE",
             "es-CO",
             "es-ES",
@@ -34,7 +41,8 @@
             "ko-US",
             "en-AU",
             "en-GB",
-            "en-AU"
+            "en-AU",
+            "ko-KR"
         ],
         "localeMap": {
             "fr-CA": "fr"

--- a/webos-js/src/msg.js
+++ b/webos-js/src/msg.js
@@ -25,6 +25,9 @@ export function findMsgByCode (code) {
         case 8:
             msg.reason = $L('OK');
             break;
+        case 9:
+            msg.reason = $L('Restart');
+            break;
         default:
             msg.reason = $L('Bye');
             break;

--- a/webos-js/test/testResources.js
+++ b/webos-js/test/testResources.js
@@ -1,7 +1,7 @@
 /*
  * testResources.js - test file to verify generated resources.
  *
- * Copyright © 2022 JEDLSoft
+ * Copyright © 2022-2023 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -185,6 +185,20 @@ function testdeDE(){
     logResults(arguments.callee.name, "EINSTELLUNGEN", result2);
 }
 
+function testasIN(){
+    var rb = new ResBundle({
+        locale:"as-IN",
+        basePath : defaultRSPath
+    });
+    var result1 = rb.getString("RETRY").toString();
+    var result2 = rb.getString("Restart").toString();
+
+    logResults(arguments.callee.name, "পুনৰ চেষ্টা", result1);
+    logResults(arguments.callee.name, "পুনৰাম্ভ কৰক", result2);
+}
+
+
+
 testkoKR();
 testkoUS();
 testenUS();
@@ -196,3 +210,4 @@ testesCO();
 testesES();
 testjaJP();
 testdeDE();
+testasIN();

--- a/webos-js/xliffs/as-IN.xliff
+++ b/webos-js/xliffs/as-IN.xliff
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="as-IN" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-js_f1" original="sample-webos-js">
+    <group id="sample-webos-js_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>RETRY</source>
+          <target>পুনৰ চেষ্টা</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>Restart</source>
+          <target>পুনৰাম্ভ কৰক</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/webos-qml/package.json
+++ b/webos-qml/package.json
@@ -5,7 +5,7 @@
     "license": "Apache-2.0",
     "version": "1.0.0",
     "scripts": {
-        "loc": "loctool -2 --xliffStyle custom --pseudo --localeMap es-CO:es --localeInherit en-AU:en-GB,en-JP:en-GB",
+        "loc": "loctool -2 --xliffStyle custom --pseudo --localeMap es-CO:es --localeInherit en-AU:en-GB,en-JP:en-GB --pseudo",
         "debug": "node --inspect-brk node_modules/loctool/loctool.js -2 --xliffStyle custom --pseudo --localeMap es-CO:es --localeInherit en-AU:en-GB",
         "clean": "rm -rf *.xliff resources",
         "test": "echo success"

--- a/webos-qml/project.json
+++ b/webos-qml/project.json
@@ -3,7 +3,13 @@
     "id": "music",
     "projectType": "webos-qml",
     "sourceLocale": "en-KR",
-    "pseudoLocale": ["zxx-XX", "zxx-Cyrl-XX", "zxx-Hans-XX", "zxx-Hebr-XX"],
+    "pseudoLocale":  {
+        "zxx-XX": "debug",
+        "zxx-Hebr-XX": "debug-rtl",
+        "zxx-Cyrl-XX": "debug-cyrillic",
+        "zxx-Hant-XX":"debug-asian",
+        "as-XX" : "debug-font"
+    },
     "resourceDirs": {
         "ts":"resources"
     },
@@ -20,6 +26,7 @@
     "settings": {
         "xliffsDir": "./xliffs",
         "locales":[
+            "as-IN",
             "en-AU",
             "en-US",
             "en-GB",

--- a/webos-qml/src/StringSheet.qml
+++ b/webos-qml/src/StringSheet.qml
@@ -33,6 +33,8 @@ AppStringSheet {
             qsTr("Exit") + es,
             qsTr("Others") + es,
             qsTr("Don\'t save") + es
+            qsTr("RETRY") + es
+            qsTr("Restart") + es
         ]
     }
     Text {

--- a/webos-qml/xliffs/as-IN.xliff
+++ b/webos-qml/xliffs/as-IN.xliff
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="as-IN" xmlns:l="http://ilib-js.com/loctool">
+  <file id="music_f1" original="music">
+    <group id="music_g1" name="x-qml">
+      <unit id="1">
+        <segment>
+          <source>RETRY</source>
+          <target>পুনৰ চেষ্টা</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>Restart</source>
+          <target>পুনৰাম্ভ কৰক</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>


### PR DESCRIPTION
* It's related https://github.com/iLib-js/loctool/pull/225, and https://github.com/iLib-js/iLib/pull/430
  It will generatae bengali pseudo string in resources/as/XX/strings.json
 ``` 
"pseudoLocale":  {
     "as-XX" : "debug-font"
},
```