### PR TITLE
Update webos-qml sample to check context name

### DIFF
--- a/webos-qml/project.json
+++ b/webos-qml/project.json
@@ -7,7 +7,7 @@
         "zxx-XX": "debug",
         "zxx-Hebr-XX": "debug-rtl",
         "zxx-Cyrl-XX": "debug-cyrillic",
-        "zxx-Hant-XX":"debug-asian",
+        "zxx-Hans-XX":"debug-asian",
         "as-XX" : "debug-font"
     },
     "resourceDirs": {

--- a/webos-qml/src/appLaunch.js
+++ b/webos-qml/src/appLaunch.js
@@ -1,0 +1,1 @@
+qsTranslate("appLaunch", "This function is not supported.")

--- a/webos-qml/src/systemUI.js
+++ b/webos-qml/src/systemUI.js
@@ -1,0 +1,1 @@
+qsTranslate("appLaunch", "This function is not supported.")

--- a/webos-qml/xliffs/ko-KR.xliff
+++ b/webos-qml/xliffs/ko-KR.xliff
@@ -70,6 +70,12 @@ Please check the Network Settings and try again.</source>
 네트워크 설정 확인 후 다시 시도하세요.</target>
     </segment>
    </unit>
+   <unit id="12">
+        <segment>
+            <source>This function is not supported.</source>
+            <target>사용할 수 없는 기능입니다.</target>
+        </segment>
+      </unit>
     </group>
   </file>
 </xliff>


### PR DESCRIPTION
Updated a webos-qml sample to see if the context name is correctly generated
 * related change:
 * https://github.com/iLib-js/ilib-loctool-webos-qml/pull/39
 * https://github.com/iLib-js/ilib-loctool-webos-ts-resource/pull/33