### PR TITLE
Update dependent packages version

### DIFF
--- a/webos-c/package.json
+++ b/webos-c/package.json
@@ -13,8 +13,8 @@
         "test": "node test/testResources.js"
     },
     "dependencies": {
-        "ilib-loctool-webos-c": "^1.6.0",
-        "ilib-loctool-webos-json-resource": "^1.5.2",
+        "ilib-loctool-webos-c": "^1.7.0",
+        "ilib-loctool-webos-json-resource": "^1.5.3",
         "loctool": "^2.22.0"
     }
 }

--- a/webos-cpp/package.json
+++ b/webos-cpp/package.json
@@ -13,8 +13,8 @@
         "test": "node test/testResources.js"
     },
     "dependencies": {
-        "ilib-loctool-webos-cpp": "^1.6.0",
-        "ilib-loctool-webos-json-resource": "^1.5.2",
+        "ilib-loctool-webos-cpp": "^1.7.0",
+        "ilib-loctool-webos-json-resource": "^1.5.3",
         "loctool": "^2.22.0"
     }
 }

--- a/webos-js/package.json
+++ b/webos-js/package.json
@@ -17,9 +17,9 @@
     },
     "dependencies": {
         "ilib": "^14.18.0",
-        "ilib-loctool-webos-javascript": "^1.9.0",
-        "ilib-loctool-webos-json": "^1.0.0",
-        "ilib-loctool-webos-json-resource": "^1.5.2",
+        "ilib-loctool-webos-javascript": "^1.10.0",
+        "ilib-loctool-webos-json": "^1.1.0",
+        "ilib-loctool-webos-json-resource": "^1.5.3",
         "loctool": "^2.22.0"
     },
     "devDependencies": {

--- a/webos-js/project.json
+++ b/webos-js/project.json
@@ -63,6 +63,9 @@
                     "template": "[dir]/[resourceDir]/[localeDir]/[filename]"
                 }
             }
+        },
+        "javascript": {
+            "disablePseudo": true
         }
     }
 }

--- a/webos-json/package.json
+++ b/webos-json/package.json
@@ -5,13 +5,13 @@
     "license": "Apache-2.0",
     "version": "1.0.0",
     "scripts": {
-        "loc": "loctool -2 --xliffStyle custom --localeMap es-CO:es --localeInherit en-AU:en-GB",
+        "loc": "loctool -2 --xliffStyle custom --localeMap es-CO:es --localeInherit en-AU:en-GB --pseudo",
         "debug": "node --inspect-brk node_modules/loctool/loctool.js -2 --xliffStyle custom --localeMap es-CO:es --localeInherit en-AU:en-GB",
         "clean": "rm -rf *.xliff resources",
         "test": "node test/testResources.js"
     },
     "devDependencies": {
-        "ilib-loctool-webos-json": "^1.0.0",
+        "ilib-loctool-webos-json": "^1.1.0",
         "loctool": "^2.22.0"
     }
 }

--- a/webos-json/subDirCase/package.json
+++ b/webos-json/subDirCase/package.json
@@ -11,7 +11,7 @@
         "test": "cd app1;node testResources.js;cd ../app2;node testResources.js"
     },
     "devDependencies": {
-        "ilib-loctool-webos-json": "^1.0.0",
+        "ilib-loctool-webos-json": "^1.1.0",
         "loctool": "^2.22.0",
         "micromatch": "^4.0.5"
     }

--- a/webos-qml/appinfo.json
+++ b/webos-qml/appinfo.json
@@ -1,0 +1,9 @@
+{
+    "id": "musc",
+    "version": "4.0.1",
+    "type": "web",
+    "main": "index.html",
+    "title": "Music",
+    "icon": "icon.png",
+    "vendor": "test"
+}

--- a/webos-qml/common/ko-KR.xliff
+++ b/webos-qml/common/ko-KR.xliff
@@ -14,6 +14,12 @@
           <target>[common] 비밀번호를 입력해 주세요.</target>
         </segment>
       </unit>
+      <unit id="common_3">
+        <segment>
+          <source>Music</source>
+          <target>음악</target>
+        </segment>
+      </unit>
     </group>
   </file>
 </xliff>

--- a/webos-qml/package.json
+++ b/webos-qml/package.json
@@ -11,8 +11,9 @@
         "test": "echo success"
     },
     "devDependencies": {
-        "ilib-loctool-webos-qml": "^1.6.0",
-        "ilib-loctool-webos-ts-resource": "^1.4.2",
+        "ilib-loctool-webos-json": "^1.1.0",
+        "ilib-loctool-webos-qml": "^1.7.0",
+        "ilib-loctool-webos-ts-resource": "^1.5.0",
         "loctool": "^2.22.0"
     }
 }

--- a/webos-qml/project.json
+++ b/webos-qml/project.json
@@ -11,10 +11,12 @@
         "as-XX" : "debug-font"
     },
     "resourceDirs": {
-        "ts":"resources"
+        "ts": "resources",
+        "json": "resources"
     },
     "resourceFileTypes": {
-        "ts":"ilib-loctool-webos-ts-resource"
+        "ts": "ilib-loctool-webos-ts-resource",
+        "json": "ilib-loctool-webos-json"
     },
     "plugins": [
         "ilib-loctool-webos-qml"
@@ -43,6 +45,16 @@
         },
         "webos": {
             "commonXliff": "./common"
+        },
+        "jsonMap": {
+            "mappings": {
+                "**/appinfo.json": {
+                    "template": "[dir]/[resourceDir]/[localeDir]/[filename]"
+                }
+            }
+        },
+        "qml": {
+            "disablePseudo" : true
         }
     }
 }


### PR DESCRIPTION
*  Update webOS sample's dependent packages version due to the new version having been released.
*  Update webos-js/webos-qml sample to check `disablePseudo : ture` option.
* Add appinfo.json file in webos-qml app to check both two types of localization work properly.