### PR TITLE
Add a sample to demo the Slack mrkdwn loctool plugin.

### DIFF
--- a/slack/README.md
+++ b/slack/README.md
@@ -1,10 +1,11 @@
 # ilib-loctool-samples/slack
 
 This project contains a sample of a project that has slack
-mrkdwn strings encoded in a a json file. Each file has the
-simple json property-value format:
+mrkdwn strings encoded in a js file. Each file exports a
+simple javascript object with the following format:
 
 ```
+    // comment for the following string
     "unique-id": "a string in slack mrkdwn syntax"
 ```
 
@@ -34,9 +35,9 @@ Before you start, run `npm install` first to install everything.
 Here are the targets you can run:
 
 - loc - run the localization tool on this project. Input is in
-translations/strings.json, and the output is in 
-translations/de/DE/strings.json and
-translations/ko/KR/strings.json
+translations/strings.js, and the output is in
+translations/de/DE/strings.js and
+translations/ko/KR/strings.js
 - debug - run the localization tool on this project with the
 chrome debugging tools. Open `chrome://inspect/#devices` in
 chrome and click on "Open dedicated DevTools for Node" to watch

--- a/slack/README.md
+++ b/slack/README.md
@@ -1,0 +1,61 @@
+# ilib-loctool-samples/slack
+
+This project contains a sample of a project that has slack
+mrkdwn strings encoded in a a json file. Each file has the
+simple json property-value format:
+
+```
+    "unique-id": "a string in slack mrkdwn syntax"
+```
+
+The markdown syntax is hidden from the translators using
+xml-like components that are number sequentially as they
+are found in the source string. So, the string
+`This is _a *mrkdwn* string_ with a <http://slack.com|link> in it.` 
+will become 
+`This is <c0>a <c1>mrkdwn</c1> string</c0> with a <c2>link</c2> in it.`
+
+Notice that the link syntax is now hidden from the translator
+so they are not able to do things like localize the URL or
+screw up the mrkdwn syntax which they might not be familiar with.
+This assumes of course that translators are at least basically
+familiar with xml, which is usually the case, but not familiar
+with mrkdwn, which is a very niche syntax.
+
+Upon localization, the components will be recomposed back into 
+Slack mrkdwn syntax. Note that in the translation, the components
+are allowed to be switched around or nested differently than
+in the source string.
+
+## Trying Them Out
+
+Before you start, run `npm install` first to install everything.
+
+Here are the targets you can run:
+
+- loc - run the localization tool on this project. Input is in
+translations/strings.json, and the output is in 
+translations/de/DE/strings.json and
+translations/ko/KR/strings.json
+- debug - run the localization tool on this project with the
+chrome debugging tools. Open `chrome://inspect/#devices` in
+chrome and click on "Open dedicated DevTools for Node" to watch
+the localization tool running in the debugger.
+- clean - clean up the localization results so that you can
+run it all again.
+
+# License
+
+Copyright (c) 2024, JEDLSoft
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/slack/package.json
+++ b/slack/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "sample-slack-json",
+    "name": "sample-slack-js",
     "type": "module",
     "description": "Sample localization project",
     "repository": "git@github.com:iLib-js/ilib-loctool-samples.git",

--- a/slack/package.json
+++ b/slack/package.json
@@ -13,6 +13,6 @@
     },
     "devDependencies": {
         "ilib-loctool-mrkdwn": "^1.0.0",
-        "loctool": "^2.25.1"
+        "loctool": "^2.25.2"
     }
 }

--- a/slack/package.json
+++ b/slack/package.json
@@ -1,0 +1,18 @@
+{
+    "name": "sample-slack-json",
+    "type": "module",
+    "description": "Sample localization project",
+    "repository": "git@github.com:iLib-js/ilib-loctool-samples.git",
+    "license": "Apache-2.0",
+    "version": "1.0.0",
+    "scripts": {
+        "loc": "loctool",
+        "debug": "node --inspect-brk node_modules/loctool/loctool.js",
+        "clean": "rm -rf *.xliff resources",
+        "test": "echo success"
+    },
+    "devDependencies": {
+        "ilib-loctool-mrkdwn": "file:../../../../../../../home/edwin/ht/ilib-loctool-mrkdwn/ilib-loctool-mrkdwn-1.0.0.tgz",
+        "loctool": "^2.25.1"
+    }
+}

--- a/slack/package.json
+++ b/slack/package.json
@@ -12,7 +12,7 @@
         "test": "echo success"
     },
     "devDependencies": {
-        "ilib-loctool-mrkdwn": "file:../../../../../../../home/edwin/ht/ilib-loctool-mrkdwn/ilib-loctool-mrkdwn-1.0.0.tgz",
+        "ilib-loctool-mrkdwn": "^1.0.0",
         "loctool": "^2.25.1"
     }
 }

--- a/slack/project.json
+++ b/slack/project.json
@@ -23,7 +23,7 @@
         ],
         "mrkdwn": {
             "mappings": {
-                "**/*.json": {
+                "**/*.js": {
                     "template": "[dir]/[localeDir]/[filename]"
                 }
             }

--- a/slack/project.json
+++ b/slack/project.json
@@ -1,0 +1,32 @@
+{
+    "name": "sample-slack-json",
+    "id": "sample-slack-json",
+    "projectType": "custom",
+    "sourceLocale": "en-US",
+    "pseudoLocale": "zxx-XX",
+    "resourceDirs": {
+        "json": "resources"
+    },
+    "plugins": [
+        "ilib-loctool-mrkdwn"
+    ],
+    "excludes": [
+        ".*",
+        "xliffs",
+        "resources"
+    ],
+    "settings": {
+        "xliffsDir": "./xliffs",
+        "locales":[
+            "ko-KR",
+            "de-DE"
+        ],
+        "mrkdwn": {
+            "mappings": {
+                "**/*.json": {
+                    "template": "[dir]/[localeDir]/[filename]"
+                }
+            }
+        }
+    }
+}

--- a/slack/translations/strings.js
+++ b/slack/translations/strings.js
@@ -1,6 +1,13 @@
 export default messages = {
+    // comment for string1
     "string1": "Hello",
+
+    // comment for string2
     "string2": "Thank *you*",
+
+    // another comment, this time for string3
     "string3": "This _is a *test* with a unique id_",
+
+    // string4 is the target of this comment
     "string4": "This is a *test* with a slack <http://www.slack.com/|link> in it and a <@user|User> reference."
 };

--- a/slack/translations/strings.js
+++ b/slack/translations/strings.js
@@ -1,6 +1,6 @@
-{
+export default messages = {
     "string1": "Hello",
     "string2": "Thank *you*",
     "string3": "This _is a *test* with a unique id_",
     "string4": "This is a *test* with a slack <http://www.slack.com/|link> in it and a <@user|User> reference."
-}
+};

--- a/slack/translations/strings.json
+++ b/slack/translations/strings.json
@@ -1,0 +1,6 @@
+{
+    "string1": "Hello",
+    "string2": "Thank *you*",
+    "string3": "This _is a *test* with a unique id_",
+    "string4": "This is a *test* with a slack <http://www.slack.com/|link> in it and a <@user|User> reference."
+}

--- a/slack/xliffs/de-DE.xliff
+++ b/slack/xliffs/de-DE.xliff
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2">
+  <file original="src/strings.json" source-language="en-US" target-language="de-DE" product-name="sample-slack-json">
+    <body>
+      <trans-unit id="2" resname="string1" restype="string" datatype="mrkdwn">
+        <source>Hello</source>
+        <target>Hallo</target>
+      </trans-unit>
+      <trans-unit id="3" resname="string2" restype="string" datatype="mrkdwn">
+        <source>Thank &lt;c0>you&lt;/c0></source>
+        <target>Danke &lt;c0>schoen&lt;/c0></target>
+      </trans-unit>
+      <trans-unit id="4" resname="string3" restype="string" datatype="mrkdwn">
+        <source>This &lt;c0>is a &lt;c1>test&lt;/c1> with a unique id&lt;/c0></source>
+        <target>Dies ist ein &lt;c1>Test&lt;/c1> mit &lt;c0>einer eindeutigen ID&lt;/c0></target>
+      </trans-unit>
+      <trans-unit id="5" resname="string4" restype="string" datatype="mrkdwn">
+        <source>This is a &lt;c0>test&lt;/c0> with a slack &lt;c1>link&lt;/c1> in it and a &lt;c2>User&lt;/c2> reference.</source>
+        <target>Dies ist ein &lt;c0>Test&lt;/c0> mit einem &lt;c1>Slack-Link&lt;/c1> und einer &lt;c2>Benutzerreferenz&lt;/c2>.</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/slack/xliffs/ko-KR.xliff
+++ b/slack/xliffs/ko-KR.xliff
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2">
+  <file original="src/strings.json" source-language="en-US" target-language="ko-KR" product-name="sample-slack-json">
+    <body>
+      <trans-unit id="2" resname="string1" restype="string" datatype="mrkdwn">
+        <source>Hello</source>
+        <target>안녕</target>
+      </trans-unit>
+      <trans-unit id="3" resname="string2" restype="string" datatype="mrkdwn">
+        <source>Thank &lt;c0>you&lt;/c0></source>
+        <target>&lt;c0>감사합니다&lt;/c0></target>
+      </trans-unit>
+      <trans-unit id="5" resname="string4" restype="string" datatype="mrkdwn">
+        <source>This is a &lt;c0>test&lt;/c0> with a slack &lt;c1>link&lt;/c1> in it and a &lt;@user|User&lt;/c2> reference.</source>
+        <target>이것은 Slack &lt;c1>링크와&lt;/c1> &lt;c2>사용자&lt;/c2> 참조가 포함된 &lt;c0>테스트&lt;/c0>입니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>


### PR DESCRIPTION
- test extracting and localizing Slack mrkdwn syntax in a json file
- comes with a few German and Korean sample translations in the xliffs dir
- output is in `translations/de/DE/strings.json` and `translations/ko/KR/strings.json`